### PR TITLE
Improve header logic and tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -374,15 +374,17 @@ def random_super_properties() -> str:
 
 
 def random_headers(token: str) -> Dict[str, str]:
-    return {
+    headers = {
         "Authorization": token,
         "User-Agent": random.choice(config.user_agents)
         if config.user_agents
         else "Mozilla/5.0",
-        "X-Fingerprint": random.choice(config.device_ids) if config.device_ids else "",
         "X-Super-Properties": random_super_properties(),
         "Content-Type": "application/json",
     }
+    if config.device_ids:
+        headers["X-Fingerprint"] = random.choice(config.device_ids)
+    return headers
 
 
 def extract_embed_text(embed: discord.Embed) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,3 +17,17 @@ def test_contains_blacklisted_empty_string():
     blacklist = ["bad"]
     assert not contains_blacklisted("", blacklist)
     assert not contains_blacklisted(None, blacklist)
+
+
+def test_random_headers_fingerprint_optional(monkeypatch):
+    import main
+
+    monkeypatch.setattr(main, 'config', type('Cfg', (), {})(), raising=False)
+    main.config.user_agents = []
+    main.config.device_ids = []
+    headers = main.random_headers('tok')
+    assert 'X-Fingerprint' not in headers
+
+    main.config.device_ids = ['abc', 'def']
+    headers = main.random_headers('tok')
+    assert headers['X-Fingerprint'] in ['abc', 'def']


### PR DESCRIPTION
## Summary
- adjust `random_headers` so X-Fingerprint header is omitted when no device IDs exist
- test the optional fingerprint behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684895723588833289cccb75f70122fb