### PR TITLE
Add virtualenv management to launch scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ Start the bot with:
 ```bash
 python main.py [-c path/to/config.json] [--token YOUR_TOKEN]
 ```
+or use the provided launch scripts, which automatically manage a virtual environment and install dependencies:
+
+- **Windows:** `launch.bat`
+- **Linux/macOS:** `./launch.sh`
+
 If the bot exits with `Invalid config`, ensure your JSON follows the schema in `config_loader.py`.
 
 ## Architecture Overview

--- a/launch.bat
+++ b/launch.bat
@@ -1,2 +1,36 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "VENV_DIR=.venv"
+
+if not exist "%VENV_DIR%\" (
+    echo Creating virtual environment in %VENV_DIR%...
+    py -3 -m venv "%VENV_DIR%" >nul 2>&1
+    if errorlevel 1 (
+        echo Python launcher not found or failed. Trying "python"...
+        python -m venv "%VENV_DIR%"
+        if errorlevel 1 (
+            echo Failed to create virtual environment.
+            exit /b 1
+        )
+    )
+)
+
+if exist "%VENV_DIR%\Scripts\activate.bat" (
+    call "%VENV_DIR%\Scripts\activate.bat"
+) else (
+    echo Virtual environment activation script not found.
+    exit /b 1
+)
+
+python -m pip install --upgrade pip
+if exist requirements.txt (
+    pip install -r requirements.txt
+) else (
+    echo requirements.txt not found. Skipping dependency installation.
+)
+
 python main.py
+
+endlocal
 pause

--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VENV_DIR=".venv"
+
+if [[ ! -d "${VENV_DIR}" ]]; then
+  echo "Creating virtual environment in ${VENV_DIR}..."
+  python3 -m venv "${VENV_DIR}"
+fi
+
+# shellcheck disable=SC1091
+source "${VENV_DIR}/bin/activate"
+
+python -m pip install --upgrade pip
+if [[ -f requirements.txt ]]; then
+  pip install -r requirements.txt
+else
+  echo "requirements.txt not found. Skipping dependency installation." >&2
+fi
+
+python main.py


### PR DESCRIPTION
## Summary
- update launch.bat to create or reuse a virtual environment, install dependencies, and run the bot
- add a Linux/macOS launch.sh with matching virtual environment management and dependency installation
- document the new launch scripts in the README

## Testing
- python -m py_compile main.py

------
https://chatgpt.com/codex/tasks/task_e_68d7cb7f25b8833284ed31c6ea1cbd65