### PR TITLE
Refine giveaway fallback reactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 
 # Logs
 logs.txt
+sniper.log
 
 # Virtual environments
 venv/

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from collections import defaultdict, deque
 from logging.handlers import RotatingFileHandler
 from typing import (
     Any,
+    Callable,
     Coroutine,
     Dict,
     List,
@@ -479,14 +480,59 @@ def redeem_nitro_coro(code: str):
 
 
 # --- Giveaway Sniping ---
-def create_smart_giveaway_entry_coro(message: discord.Message):
-    """Returns a coroutine that tries to click a button, falling back to a reaction."""
+def _encode_reaction_emoji_identifier(emoji: Any) -> Optional[str]:
+    """Converts an emoji representation into the identifier expected by the HTTP API."""
+    if emoji is None:
+        return None
+
+    if isinstance(emoji, str):
+        return discord.http._uriquote(emoji)
+
+    emoji_id = getattr(emoji, "id", None)
+    emoji_name = getattr(emoji, "name", None)
+
+    if emoji_id:
+        if not emoji_name:
+            return None
+        prefix = "a:" if getattr(emoji, "animated", False) else ""
+        return f"{prefix}{emoji_name}:{emoji_id}"
+
+    if emoji_name:
+        return discord.http._uriquote(emoji_name)
+
+    return None
+
+
+def _collect_existing_reaction_identifiers(message: discord.Message) -> List[str]:
+    """Returns encoded reaction identifiers for reactions not made by the current user."""
+    identifiers: List[str] = []
+    for reaction in getattr(message, "reactions", []):
+        if getattr(reaction, "me", False):
+            continue
+
+        count = getattr(reaction, "count", 0)
+        if count is not None and count <= 0:
+            continue
+
+        identifier = _encode_reaction_emoji_identifier(getattr(reaction, "emoji", None))
+        if identifier:
+            identifiers.append(identifier)
+
+    return identifiers
+
+
+def create_smart_giveaway_entry_coro(message: discord.Message) -> Optional[Callable[[aiohttp.ClientSession, Dict[str, str]], Coroutine[Any, Any, aiohttp.ClientResponse]]]:
+    """Returns a coroutine that tries to click a button, falling back to existing reactions."""
     first_button = next((child for comp in message.components for child in comp.children if isinstance(child, discord.Button)), None)
-    
+    available_reactions = _collect_existing_reaction_identifiers(message)
+
+    if not first_button and not available_reactions:
+        return None
+
     interaction_url = "https://discord.com/api/v10/interactions"
-    reaction_url = f"https://discord.com/api/v10/channels/{message.channel.id}/messages/{message.id}/reactions/🎉/@me"
 
     async def _coro(session: aiohttp.ClientSession, headers: Dict[str, str]) -> aiohttp.ClientResponse:
+        button_response: Optional[aiohttp.ClientResponse] = None
         if first_button:
             await logger.log(f"Attempting button click for giveaway in {message.guild.name}...", logging.DEBUG)
             payload = {
@@ -501,14 +547,35 @@ def create_smart_giveaway_entry_coro(message: discord.Message):
                 if 200 <= button_response.status < 300:
                     await logger.log(f"Button click successful in {message.guild.name}.", logging.DEBUG)
                     return button_response
-                
+
                 response_text = await button_response.text()
-                await logger.log(f"Button click in {message.guild.name} failed (Status {button_response.status}). Response: {response_text[:200]}. Falling back to reaction.", logging.WARNING)
+                await logger.log(f"Button click in {message.guild.name} failed (Status {button_response.status}). Response: {response_text[:200]}. Falling back to reactions.", logging.WARNING)
             except Exception as e:
-                await logger.log(f"Exception during button click in {message.guild.name}: {e}. Falling back to reaction.", logging.ERROR)
-        
-        await logger.log(f"Attempting reaction for giveaway in {message.guild.name}...", logging.DEBUG)
-        return await session.put(reaction_url, headers=headers, timeout=10)
+                await logger.log(f"Exception during button click in {message.guild.name}: {e}. Falling back to reactions.", logging.ERROR)
+                if not available_reactions:
+                    raise
+
+        if not available_reactions:
+            if button_response is None:
+                raise RuntimeError("Button interaction failed and no reactions available to fall back on.")
+            return button_response
+
+        await logger.log(f"Attempting existing reactions for giveaway in {message.guild.name}...", logging.DEBUG)
+
+        last_response: Optional[aiohttp.ClientResponse] = None
+        for reaction_identifier in available_reactions:
+            reaction_url = (
+                f"https://discord.com/api/v10/channels/{message.channel.id}/messages/{message.id}/reactions/{reaction_identifier}/@me"
+            )
+            response = await session.put(reaction_url, headers=headers, timeout=10)
+            if last_response is not None:
+                await last_response.read()
+            last_response = response
+
+        if last_response is None:
+            raise RuntimeError("No reactions were processed while attempting to join the giveaway.")
+        return last_response
+
     return _coro
 
 
@@ -603,6 +670,9 @@ class SniperClient(commands.Bot):
         if any(r.emoji == "🎉" for r in message.reactions if r.me): return
 
         interaction_coro = create_smart_giveaway_entry_coro(message)
+        if interaction_coro is None:
+            return
+
         await logger.log(f"Giveaway found in {message.guild.name}. Queuing smart entry.", logging.DEBUG)
 
         delay = random.uniform(settings.min_delay_sec, settings.max_delay_sec)

--- a/tests/test_giveaway.py
+++ b/tests/test_giveaway.py
@@ -1,0 +1,65 @@
+import unittest
+from types import SimpleNamespace
+
+import main
+
+
+class FakeReaction:
+    def __init__(self, emoji, count, me=False):
+        self.emoji = emoji
+        self.count = count
+        self.me = me
+
+
+class FakeCustomEmoji:
+    def __init__(self, name, emoji_id, animated=False):
+        self.name = name
+        self.id = emoji_id
+        self.animated = animated
+
+
+class FakeMessage:
+    def __init__(self, reactions):
+        self.reactions = reactions
+        self.components = []
+        self.guild = SimpleNamespace(name="Guild", id=1)
+        self.channel = SimpleNamespace(name="general", id=2)
+        self.author = SimpleNamespace(id=3)
+        self.id = 4
+
+
+class GiveawayHelperTests(unittest.TestCase):
+    def test_encode_unicode_emoji(self):
+        encoded = main._encode_reaction_emoji_identifier("🎉")
+        self.assertEqual(encoded, "%F0%9F%8E%89")
+
+    def test_encode_custom_emoji(self):
+        emoji = FakeCustomEmoji("party", 12345, animated=True)
+        encoded = main._encode_reaction_emoji_identifier(emoji)
+        self.assertEqual(encoded, "a:party:12345")
+
+    def test_collect_existing_reactions_filters_self_and_empty(self):
+        reactions = [
+            FakeReaction("🎉", 3, me=False),
+            FakeReaction("👍", 0, me=False),
+            FakeReaction("🔥", 2, me=True),
+        ]
+        message = FakeMessage(reactions)
+
+        identifiers = main._collect_existing_reaction_identifiers(message)
+
+        self.assertEqual(identifiers, ["%F0%9F%8E%89"])
+
+    def test_create_smart_coro_returns_none_when_no_actions_available(self):
+        message = FakeMessage(reactions=[])
+        interaction_coro = main.create_smart_giveaway_entry_coro(message)
+        self.assertIsNone(interaction_coro)
+
+    def test_create_smart_coro_uses_reactions_when_available(self):
+        message = FakeMessage(reactions=[FakeReaction("🎉", 1)])
+        interaction_coro = main.create_smart_giveaway_entry_coro(message)
+        self.assertTrue(callable(interaction_coro))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid reacting to giveaways when no buttons or existing emoji reactions are available
- reuse all existing giveaway reactions when falling back from button interaction
- add unit tests covering emoji encoding and reaction selection helpers

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68d7dabc8d0083329a7f9e4dd511c27f